### PR TITLE
fix_mail_reply_to

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -71,12 +71,14 @@
             <tag name="kernel.event_subscriber"/>
         </service>
         <service id="paypal.order.listener" class="PayPal\EventListeners\OrderListener">
-            <argument type="service" id="mailer"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="paypal_payment_service"/>
             <argument type="service" id="paypal_agreement_service"/>
             <tag name="kernel.event_subscriber"/>
+            <call method="setCustomerMailer">
+                <argument type="service" id="core.customer.mailer"/>
+            </call>
         </service>
         <service id="paypal.plan.listener" class="PayPal\EventListeners\PayPalPlanListener">
             <tag name="kernel.event_subscriber"/>

--- a/Config/config.xml
+++ b/Config/config.xml
@@ -75,10 +75,8 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="paypal_payment_service"/>
             <argument type="service" id="paypal_agreement_service"/>
+            <argument type="service" id="core.customer.mailer"/>
             <tag name="kernel.event_subscriber"/>
-            <call method="setCustomerMailer">
-                <argument type="service" id="core.customer.mailer"/>
-            </call>
         </service>
         <service id="paypal.plan.listener" class="PayPal\EventListeners\PayPalPlanListener">
             <tag name="kernel.event_subscriber"/>

--- a/EventListeners/OrderListener.php
+++ b/EventListeners/OrderListener.php
@@ -23,7 +23,7 @@
 
 namespace PayPal\EventListeners;
 
-use ApyUtilities\Interfaces\CustomerMailerInterface;
+use ApyUtilities\Email\AbstractCustomerMailer;
 use PayPal\Event\PayPalCartEvent;
 use PayPal\Event\PayPalEvents;
 use PayPal\Form\PayPalFormFields;
@@ -43,7 +43,7 @@ use Thelia\Core\Event\TheliaEvents;
  */
 class OrderListener implements EventSubscriberInterface
 {
-    /** @var CustomerMailerInterface */
+    /** @var AbstractCustomerMailer */
     private $customerMailer;
 
     /** @var EventDispatcherInterface */
@@ -60,24 +60,18 @@ class OrderListener implements EventSubscriberInterface
 
     /**
      * @param EventDispatcherInterface $dispatcher
-     * @param RequestStack $requestStack
-     * @param PayPalPaymentService $payPalPaymentService
-     * @param PayPalAgreementService $payPalAgreementService
+     * @param RequestStack             $requestStack
+     * @param PayPalPaymentService     $payPalPaymentService
+     * @param PayPalAgreementService   $payPalAgreementService
+     * @param AbstractCustomerMailer   $customerMailer
      */
-    public function __construct(EventDispatcherInterface $dispatcher, RequestStack $requestStack, PayPalPaymentService $payPalPaymentService, PayPalAgreementService $payPalAgreementService)
+    public function __construct(EventDispatcherInterface $dispatcher, RequestStack $requestStack, PayPalPaymentService $payPalPaymentService, PayPalAgreementService $payPalAgreementService, AbstractCustomerMailer $customerMailer)
     {
         $this->dispatcher = $dispatcher;
         $this->requestStack = $requestStack;
         $this->payPalPaymentService = $payPalPaymentService;
         $this->payPalAgreementService = $payPalAgreementService;
-    }
-
-    /**
-     * @param CustomerMailerInterface $customerMailer
-     */
-    public function setCustomerMailer(CustomerMailerInterface $customerMailer)
-    {
-        $this->customerMailer = $customerMailer;
+        $this->customerMailer     = $customerMailer;
     }
 
     /**

--- a/EventListeners/OrderListener.php
+++ b/EventListeners/OrderListener.php
@@ -23,6 +23,7 @@
 
 namespace PayPal\EventListeners;
 
+use ApyUtilities\Interfaces\CustomerMailerInterface;
 use PayPal\Event\PayPalCartEvent;
 use PayPal\Event\PayPalEvents;
 use PayPal\Form\PayPalFormFields;
@@ -35,7 +36,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Mailer\MailerFactory;
 
 /**
  * Class OrderListener
@@ -43,8 +43,8 @@ use Thelia\Mailer\MailerFactory;
  */
 class OrderListener implements EventSubscriberInterface
 {
-    /** @var MailerFactory */
-    protected $mailer;
+    /** @var CustomerMailerInterface */
+    private $customerMailer;
 
     /** @var EventDispatcherInterface */
     protected $dispatcher;
@@ -59,19 +59,25 @@ class OrderListener implements EventSubscriberInterface
     protected $payPalAgreementService;
 
     /**
-     * @param MailerFactory $mailer
      * @param EventDispatcherInterface $dispatcher
      * @param RequestStack $requestStack
      * @param PayPalPaymentService $payPalPaymentService
      * @param PayPalAgreementService $payPalAgreementService
      */
-    public function __construct(MailerFactory $mailer, EventDispatcherInterface $dispatcher, RequestStack $requestStack, PayPalPaymentService $payPalPaymentService, PayPalAgreementService $payPalAgreementService)
+    public function __construct(EventDispatcherInterface $dispatcher, RequestStack $requestStack, PayPalPaymentService $payPalPaymentService, PayPalAgreementService $payPalAgreementService)
     {
         $this->dispatcher = $dispatcher;
-        $this->mailer = $mailer;
         $this->requestStack = $requestStack;
         $this->payPalPaymentService = $payPalPaymentService;
         $this->payPalAgreementService = $payPalAgreementService;
+    }
+
+    /**
+     * @param CustomerMailerInterface $customerMailer
+     */
+    public function setCustomerMailer(CustomerMailerInterface $customerMailer)
+    {
+        $this->customerMailer = $customerMailer;
     }
 
     /**
@@ -110,7 +116,7 @@ class OrderListener implements EventSubscriberInterface
 
         if ($order->isPaid() && $order->getPaymentModuleId() === Paypal::getModuleId()) {
             if (Paypal::getConfigValue('send_payment_confirmation_message')) {
-                $this->mailer->sendEmailToCustomer(
+                $this->customerMailer->sendEmailToCustomer(
                     PayPal::CONFIRMATION_MESSAGE_NAME,
                     $order->getCustomer(),
                     [
@@ -150,9 +156,8 @@ class OrderListener implements EventSubscriberInterface
     public function recursivePayment(OrderEvent $event)
     {
         $this->payPalAgreementService->duplicateOrder($event->getOrder());
-
         if (PayPal::getConfigValue('send_recursive_message')) {
-            $this->mailer->sendEmailToCustomer(
+            $this->customerMailer->sendEmailToCustomer(
                 PayPal::RECURSIVE_MESSAGE_NAME,
                 $event->getOrder()->getCustomer(),
                 [


### PR DESCRIPTION
### Type de MR
FIX_mail_reply_to 

### Ticket
https://www.demandedesupport.com/issues/651643

### Impact
consommateur

### Phrase de description dans le mail de livraison
`Fix du reply-to pour les mails transactionnels` 

### Procédure de tests
+ Déclancher les differents envois des mails depuis la console. 


### Explication plus technique
Le bon code d'envoi de mail est la fonction sendEmailMessageWithReplyTo() dans la classe CustomerMail (anciennement dans le module ApyMyBox, mais deplacée dans ApyUtilities) 
La correction consiste donc a appeler la fonction de cette classe pour tout les envois de mails. 



### Lié aux MR ::
+ [MR ApyUtilities](https://git.centraldev.api-and-you.com/apymybox/ApyUtilities/-/merge_requests/312)
+ [MR ApyStoreConfiguration](https://git.centraldev.api-and-you.com/apymybox/apystoreconfiguration/-/merge_requests/137)
+ [MR ApyPayzone](https://git.centraldev.api-and-you.com/apymybox/ApyPayzone/-/merge_requests/16)
+ [MR ApyCustomJulesVerne](https://git.centraldev.api-and-you.com/apymybox/apycustomjulesverne/-/merge_requests/59)
+ [MR ApyPayzenShared](https://git.centraldev.api-and-you.com/apymybox/apypayzenshared/-/merge_requests/47)
+ [MR ApyMyBox](https://git.centraldev.api-and-you.com/apymybox/apymybox/-/merge_requests/2416)
+ [MR ApyFundJar](https://git.centraldev.api-and-you.com/apymybox/ApyFundJar/-/merge_requests/22)
+ [MR PayPal](https://github.com/lesateliersapicius/Paypal/pull/4)