### PR TITLE
fix_eventdispatcher_943305

### DIFF
--- a/Controller/PayPalWebHookController.php
+++ b/Controller/PayPalWebHookController.php
@@ -33,7 +33,6 @@ use PayPal\PayPal;
 use PayPal\Service\PayPalAgreementService;
 use PayPal\Service\PayPalLoggerService;
 use Propel\Runtime\Propel;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Controller\Front\BaseFrontController;

--- a/EventListeners/PayPalCustomerListener.php
+++ b/EventListeners/PayPalCustomerListener.php
@@ -25,7 +25,6 @@ namespace PayPal\EventListeners;
 
 use PayPal\Event\PayPalCustomerEvent;
 use PayPal\Event\PayPalEvents;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -39,18 +38,18 @@ class PayPalCustomerListener implements EventSubscriberInterface
     /** @var RequestStack */
     protected $requestStack;
 
-    /** @var EventDispatcher */
+    /** @var EventDispatcherInterface */
     protected $dispatcher;
 
     /**
      * PayPalCustomerListener constructor.
-     * @param RequestStack $requestStack
-     * @param EventDispatcher $dispatcher
+     * @param RequestStack             $requestStack
+     * @param EventDispatcherInterface $dispatcher
      */
     public function __construct(RequestStack $requestStack, EventDispatcherInterface $dispatcher)
     {
         $this->requestStack = $requestStack;
-        $this->dispatcher = $dispatcher;
+        $this->dispatcher   = $dispatcher;
     }
 
     /**


### PR DESCRIPTION
### Type de MR
FIX

### Ticket
https://www.demandedesupport.com/issues/943305

### Impact
utilisateur|consommateur|interne

### Phrase de description dans le mail de livraison
`[SecretBox] - EventDispatcher sur thelia 25` 

### Explication plus technique
+ Suppression des import d'EventDispatcher pour utilisé l'EventDispatcherInterface

### Lié aux MR ::
+ https://github.com/lesateliersapicius/Paypal/pull/9
+ https://git.centraldev.api-and-you.com/apymybox/ApySupportTicket/-/merge_requests/87
+ https://git.centraldev.api-and-you.com/apymybox/apymybox/-/merge_requests/2890
+ https://git.centraldev.api-and-you.com/apymybox/ApyMediaLibrary/-/merge_requests/104
+ https://git.centraldev.api-and-you.com/apymybox/apygoogleshopping/-/merge_requests/19
+ https://git.centraldev.api-and-you.com/apymybox/ApyFundJar/-/merge_requests/57
+ https://git.centraldev.api-and-you.com/apymybox/apycustomducasse/-/merge_requests/29

/label ~"SecretBox next master" 
/label ~"Thelia 2.5" 
