### PR TITLE
fix_missing_module_language_1206869

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -14,6 +14,21 @@
     <descriptive locale="fr_FR">
         <title>PayPal</title>
     </descriptive>
+    <descriptive locale="it_IT">
+        <title>PayPal</title>
+    </descriptive>
+    <descriptive locale="es_ES">
+        <title>PayPal</title>
+    </descriptive>
+    <descriptive locale="de_DE">
+        <title>PayPal</title>
+    </descriptive>
+    <descriptive locale="ru_RU">
+        <title>PayPal</title>
+    </descriptive>
+    <descriptive locale="cs_CZ">
+        <title>PayPal</title>
+    </descriptive>
     <!-- <logo></logo> -->
     <!--<images-folder>images</images-folder>-->
     <languages>

--- a/Migration/Migration20250423104754.php
+++ b/Migration/Migration20250423104754.php
@@ -5,6 +5,7 @@ namespace PayPal\Migration;
 use ApyUtilities\Model\Migration\AbstractMigration;
 use PDO;
 use Propel\Runtime\Propel;
+use Thelia\Model\ModuleI18n;
 use Thelia\Model\ModuleI18nQuery;
 
 /**
@@ -84,16 +85,16 @@ class Migration20250423104754 extends AbstractMigration
      */
     private function needMigration(): bool
     {
-        foreach(self::AVAILABLE_LANGUAGES as $lang) {
+        foreach (self::AVAILABLE_LANGUAGES as $lang) {
             $PaypalModuleLanguages = ModuleI18nQuery::create()->filterByLocale($lang)
                 ->filterByTitle('PayPal')
                 ->findOne();
 
-            if (null === $PaypalModuleLanguages) {
+            if (!$PaypalModuleLanguages instanceof ModuleI18n) {
                 $this->missingLanguages[] = $lang;
-                return true;
             }
         }
-        return false;
+
+        return !empty($this->missingLanguages);
     }
 }

--- a/Migration/Migration20250423104754.php
+++ b/Migration/Migration20250423104754.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PayPal\Migration;
+
+use ApyUtilities\Model\Migration\AbstractMigration;
+use PDO;
+use Propel\Runtime\Propel;
+use Thelia\Model\ModuleI18nQuery;
+
+/**
+ * Migration pour rajouter le module PayPal dans toutes les langues disponibles dans le FO
+ * Class Migration20250423104754
+ * @package PayPal\Migration
+ */
+class Migration20250423104754 extends AbstractMigration
+{
+    const AVAILABLE_LANGUAGES = [
+        'cs_CZ',
+        'de_DE',
+        'en_US',
+        'es_ES',
+        'fr_FR',
+        'it_IT',
+        'ru_RU',
+    ];
+
+    private $missingLanguages = [];
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkDuringActivation(): bool
+    {
+        return $this->needMigration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function runDuringActivation()
+    {
+        $this->doRun();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkDuringMigration(): bool
+    {
+        return $this->needMigration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function runDuringMigration()
+    {
+        $this->doRun();
+    }
+
+    private function doRun()
+    {
+        // Rajoute le module PayPal dans la langue manquante
+        $paypalModuleId = ModuleI18nQuery::create()->findOneByTitle('PayPal');
+        if ($paypalModuleId) {
+            $moduleId = $paypalModuleId->getId();
+            foreach ($this->missingLanguages as $language) {
+                /** @var PDO $con */
+                $con = Propel::getConnection();
+
+                $sql = <<<SQL
+                    INSERT INTO module_i18n (id, locale, title)
+                    VALUES ($moduleId , '$language', 'PayPal')
+                SQL;
+
+                $con->exec($sql);
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function needMigration(): bool
+    {
+        foreach(self::AVAILABLE_LANGUAGES as $lang) {
+            $PaypalModuleLanguages = ModuleI18nQuery::create()->filterByLocale($lang)
+                ->filterByTitle('PayPal')
+                ->findOne();
+
+            if (null === $PaypalModuleLanguages) {
+                $this->missingLanguages[] = $lang;
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
### Type de MR
FIX

### Ticket
https://www.demandedesupport.com/issues/1206869

### Impact
consommateur

### Phrase de description dans le mail de livraison
`Visibilité du logo Paypal au footer sur les autres langues` 

### Procédure de tests
+ Commencer vos tests sur la branche `master_t25`
+ Activer PayPal `php Thelia mod:act Paypal`
+ Remplisser des infos au hasard (pas besoin de vraies infos) pour activer le module PayPal
+ Activer la langue italienne (ou une autre) et (mettez-la par défaut)
+ Le logo PayPal dans le footer du FO ne doit pas apparaitre
+ Maintenant changer de branche : `fix_missing_module_language_1206869`
+ Lancer les migrations (`php Thelia apy:up`) ou (`php Thelia apy-migration-manager:exec PayPal\\Migration\\Migration20250423104754`)
+ Le logo PayPal doit apparaitre dans le Footer

### Explication plus technique
+ Dans la table module_i18n, il n'y avait que le `fr_FR` et le `en_US`. Mais quand on choisi une autre langue par défaut, il n'y a plus d'enregistrement => plus de logo dans le footer