### PR TITLE
fix_spam_paypal_1237065

### DIFF
--- a/Controller/PayPalResponseController.php
+++ b/Controller/PayPalResponseController.php
@@ -23,6 +23,7 @@
 
 namespace PayPal\Controller;
 
+use ApyMyBox\Helper\OrderHelper;
 use ApyUtilities\Event\PaymentEventInterface;
 use ApyUtilities\Interfaces\OrderHelperInterface;
 use Front\Controller\OrderController;
@@ -99,7 +100,7 @@ class PayPalResponseController extends OrderController
      * @param $orderId
      * @param RequestStack $requestStack
      * @param EventDispatcherInterface $eventDispatcher
-     * @return RedirectResponse
+     * @return RedirectResponse|void
      * @Route("/module/paypal/ok/{orderId}", name="_ok", methods="GET")
      */
     public function okAction($orderId, RequestStack $requestStack, EventDispatcherInterface $eventDispatcher)
@@ -108,14 +109,21 @@ class PayPalResponseController extends OrderController
         $con->beginTransaction();
 
         try {
-            $request = $requestStack->getCurrentRequest();
-            $payerId = $request->query->get('PayerID');
-            $token = $request->query->get('token');
+            $request     = $requestStack->getCurrentRequest();
+            $payerId     = $request->query->get('PayerID');
+            $token       = $request->query->get('token');
             $payPalOrder = PaypalOrderQuery::create()->findOneById($orderId);
+            $order       = OrderQuery::create()->findOneById($orderId);
+
+            // Si la commande est déjà en statut "payé", on ne rejoue pas le processus de paiement
+            if (OrderHelper::isOrderPaid($order)) {
+                return;
+            }
 
             if (null !== $payPalOrder && null !== $payerId) {
 
-                $response = $this->executePayment($eventDispatcher, $payPalOrder, $payPalOrder->getPaymentId(), $payerId, $token);
+                $response = $this->executePayment($eventDispatcher, $payPalOrder, $payPalOrder->getPaymentId(),
+                    $payerId, $token);
             } else {
                 $con->rollBack();
                 $message = Translator::getInstance()->trans(
@@ -159,9 +167,7 @@ class PayPalResponseController extends OrderController
             $response = $this->getPaymentFailurePageUrl($orderId, $e->getMessage());
         }
 
-
         $con->commit();
-
 
         $order = OrderQuery::create()
             ->findOneById($orderId);

--- a/Controller/PayPalResponseController.php
+++ b/Controller/PayPalResponseController.php
@@ -23,7 +23,6 @@
 
 namespace PayPal\Controller;
 
-use ApyUtilities\ApyUtilities;
 use ApyUtilities\Event\PaymentEventInterface;
 use ApyUtilities\Interfaces\OrderHelperInterface;
 use Front\Controller\OrderController;
@@ -97,14 +96,19 @@ class PayPalResponseController extends OrderController
     }
 
     /**
-     * @param $orderId
-     * @param RequestStack $requestStack
+     * @param                          $orderId
+     * @param RequestStack             $requestStack
      * @param EventDispatcherInterface $eventDispatcher
+     * @param OrderHelperInterface     $orderHelper
      * @return RedirectResponse|void
      * @Route("/module/paypal/ok/{orderId}", name="_ok", methods="GET")
      */
-    public function okAction($orderId, RequestStack $requestStack, EventDispatcherInterface $eventDispatcher)
-    {
+    public function okAction(
+        $orderId,
+        RequestStack $requestStack,
+        EventDispatcherInterface $eventDispatcher,
+        OrderHelperInterface $orderHelper
+    ) {
         $con = Propel::getConnection();
         $con->beginTransaction();
 
@@ -116,17 +120,18 @@ class PayPalResponseController extends OrderController
             $order       = OrderQuery::create()->findOneById($orderId);
 
             // Si la commande est déjà en statut "payé", on ne rejoue pas le processus de paiement
-            if (ApyUtilities::isSecretBox() && \ApyMyBox\Helper\OrderHelper::isOrderPaid($order)) {
-                return;
-            }
-            if (ApyUtilities::isShopAndGo() && \ApyShopAndGo\Helper\OrderHelper::isOrderPaid($order)) {
+            if ($orderHelper::isOrderPaid($order)) {
                 return;
             }
 
             if (null !== $payPalOrder && null !== $payerId) {
-
-                $response = $this->executePayment($eventDispatcher, $payPalOrder, $payPalOrder->getPaymentId(),
-                    $payerId, $token);
+                $response = $this->executePayment(
+                    $eventDispatcher,
+                    $payPalOrder,
+                    $payPalOrder->getPaymentId(),
+                    $payerId,
+                    $token
+                );
             } else {
                 $con->rollBack();
                 $message = Translator::getInstance()->trans(

--- a/Controller/PayPalResponseController.php
+++ b/Controller/PayPalResponseController.php
@@ -23,7 +23,7 @@
 
 namespace PayPal\Controller;
 
-use ApyMyBox\Helper\OrderHelper;
+use ApyUtilities\ApyUtilities;
 use ApyUtilities\Event\PaymentEventInterface;
 use ApyUtilities\Interfaces\OrderHelperInterface;
 use Front\Controller\OrderController;
@@ -116,7 +116,10 @@ class PayPalResponseController extends OrderController
             $order       = OrderQuery::create()->findOneById($orderId);
 
             // Si la commande est déjà en statut "payé", on ne rejoue pas le processus de paiement
-            if (OrderHelper::isOrderPaid($order)) {
+            if (ApyUtilities::isSecretBox() && \ApyMyBox\Helper\OrderHelper::isOrderPaid($order)) {
+                return;
+            }
+            if (ApyUtilities::isShopAndGo() && \ApyShopAndGo\Helper\OrderHelper::isOrderPaid($order)) {
                 return;
             }
 


### PR DESCRIPTION
### Type de MR
FIX

### Ticket
https://www.demandedesupport.com/issues/1237065

### Impact
utilisateur|consommateur|interne

### Phrase de description dans le mail de livraison
`Plusieurs notifs pour une même commande` 

### Procédure de tests
+ Passer une commande avec paypal 
+ http://wiki.api-and-you.net/fr/developpement/secretbox/Utilisation_de_paypal_en_local
+ Récupérer dans la table admin log la route que paypal utilise pour nous rappeler (exemple : http://secretbox.docker/module/paypal/ok/221?paymentId=xxxx&token=xxxx&PayerID=xxxx)
+ Rejouer cette URL, vous ne devez pas recevoir de nouveau mails et la référence du bon doit rester la même.

### Explication plus technique
+ Sur la route que paypal appel, on retourne rien si la commande est déjà payé. Evite que le processus de paiement soit réjouée (nouveau mail, nouvelle ref de bon ...)