### PR TITLE
feature_reminder_fundjar_603338

### DIFF
--- a/EventListeners/OrderListener.php
+++ b/EventListeners/OrderListener.php
@@ -138,7 +138,8 @@ class OrderListener implements EventSubscriberInterface
         $payPalCartEvent = new PayPalCartEvent($this->payPalPaymentService->getCurrentPayPalCart());
         $this->dispatcher->dispatch($payPalCartEvent, PayPalEvents::PAYPAL_CART_DELETE);
 
-        $postedData = $this->requestStack->getCurrentRequest()->request->all()['thelia_order_payment'];
+        $allPosted = $this->requestStack->getCurrentRequest()->request->all();
+        $postedData = $allPosted['thelia_order_payment'] ?? $allPosted['apyfundjar_payment_form'] ?? [];
 
         if (isset($postedData[PayPalFormFields::FIELD_PAYMENT_MODULE]) && PayPal::getModuleId() === $event->getOrder()->getPaymentModuleId()) {
             $this->usePayPalMethod($postedData);


### PR DESCRIPTION
### Type de MR
FEATURE

### Ticket
https://www.demandedesupport.com/issues/603338

### Impact
consommateur

### Phrase de description dans le mail de livraison
`Mail transactionnel : relancer la participation d'une cagnotte ` 

### Procédure de tests
+ Pour mettre en place la feature : `make apyup` & `php Thelia apy-my-box:load:messages`
+ Premièrement, créer une cagnotte et y ajouter des participants (utiliser un ou plusieurs yopmail afin de recevoir les mails de relance)
+ Tester l'envoie du mail de relance : `php Thelia apy-my-box:execute:schedulled:task ApyFundJar\\TaskScheduler\\SendFundJarReminder`
+ Jouer avec la `end_date` de `apy_fund_jar_order_product` pour se rendre à J-2 de la cloturation d'une cagnotte
  + Vérifier que la relance s'éxecute bien à j-2
  + Uniquement les participants en attente de paiement doivent recevoir un mail
  + Si mail déjà envoyé (reminder_sent), ne doit pas le renvoyer 
  + Si plusieurs participants avec un mail identique, envoie d'un seul mail
  + Vérifier l'affichage du mail avec la note #1 du ticket
+ Dans BO -> Communiquer -> E-mails transactionnels -> fund_jar_reminder
  + Vous pouvez prévisualiser ou modifier le template de mail 

### Explication plus technique
+ Fix un bug dans le module Paypal pour le passage d'une cagnotte
+ Relance à J-2 les participants en attente de paiement d'une cagnotte
+ Ajout de la colonne `reminder_sent` dans `apy_fund_jar_participant` afin de savoir si le mail de relance a deja été fait
+ nouveaux templates de mail
+ ajout d'une nouvelle tache planifié `SendFundJarReminder.php` (Execution des TP à 00h30)

### Lié aux MR ::
+ https://git.centraldev.api-and-you.com/apymybox/ApyFundJar/-/merge_requests/77
+ https://git.centraldev.api-and-you.com/apymybox/apymybox/-/merge_requests/3534
+ https://github.com/lesateliersapicius/Paypal/pull/19